### PR TITLE
Add TF-IDF DocumentSearchIndex with synonyms and integrate into CommandMenu

### DIFF
--- a/__tests__/document-search.test.ts
+++ b/__tests__/document-search.test.ts
@@ -1,0 +1,161 @@
+import {
+  DocumentSearchIndex,
+  searchFields,
+} from "@/lib/search/document-search";
+
+type Article = {
+  slug: string;
+  metadata: {
+    title: string;
+    summary: string;
+  };
+  content: string;
+};
+
+type Exercise = {
+  aliases: string[] | null;
+  category: "strength" | "stretching";
+  date_created: string;
+  date_updated: string;
+  description: string | null;
+  equipment: "barbell" | "dumbbell" | null;
+  force: "push" | "pull" | null;
+  id: string;
+  instructions: string[] | null;
+  level: "beginner" | "intermediate";
+  mechanic: "compound" | "isolation" | null;
+  name: string;
+  primary_muscles: string[] | null;
+  secondary_muscles: string[] | null;
+  tips: string[] | null;
+};
+
+const articles: Article[] = [
+  {
+    slug: "errors",
+    metadata: {
+      title: "Client side error handling",
+      summary: "Typed failures in server actions",
+    },
+    content:
+      "The article explains exceptions, validation faults, and frontend messages.",
+  },
+  {
+    slug: "cdn",
+    metadata: {
+      title: "Caching and content delivery networks",
+      summary: "How edge caches improve website performance",
+    },
+    content:
+      "Store responses near users with stale if error behavior and SSL termination.",
+  },
+  {
+    slug: "clean-code",
+    metadata: {
+      title: "Heuristics for clean code",
+      summary: "Principles for readable software",
+    },
+    content: "Guidelines keep modules maintainable and tidy.",
+  },
+];
+
+const articleText = searchFields<Article>(
+  (article) => article.metadata.title,
+  (article) => article.metadata.summary,
+  (article) => article.content,
+);
+
+describe("DocumentSearchIndex", () => {
+  it("ranks documents by caller-selected string fields", () => {
+    const index = new DocumentSearchIndex(articles, { getText: articleText });
+
+    const [result] = index.search("validation fault messages");
+
+    expect(result.document.slug).toBe("errors");
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  it("expands configured synonyms so semantic matches are returned", () => {
+    const index = new DocumentSearchIndex(articles, { getText: articleText });
+
+    const [result] = index.search("browser exception");
+
+    expect(result.document.slug).toBe("errors");
+    expect(result.matchedTerms).toEqual(
+      expect.arrayContaining(["client", "error"]),
+    );
+  });
+
+  it("allows package-like consumers to provide domain synonyms without app coupling", () => {
+    const index = new DocumentSearchIndex(articles, {
+      getText: articleText,
+      synonyms: {
+        resilient: ["stale"],
+      },
+    });
+
+    const [result] = index.search("resilient responses");
+
+    expect(result.document.slug).toBe("cdn");
+  });
+
+  it("indexes arbitrary objects with different keys, arrays, nullable values, and enum-like values", () => {
+    const exercises: Exercise[] = [
+      {
+        aliases: ["bench press", "chest press"],
+        category: "strength",
+        date_created: "2024-01-01",
+        date_updated: "2024-01-02",
+        description: "Horizontal pressing movement for upper body strength.",
+        equipment: "barbell",
+        force: "push",
+        id: "barbell-bench-press",
+        instructions: ["Lie on the bench", "Press the bar from the chest"],
+        level: "beginner",
+        mechanic: "compound",
+        name: "Barbell Bench Press",
+        primary_muscles: ["chest"],
+        secondary_muscles: ["triceps", "shoulders"],
+        tips: null,
+      },
+      {
+        aliases: null,
+        category: "strength",
+        date_created: "2024-01-01",
+        date_updated: "2024-01-02",
+        description: "Lower body squat pattern.",
+        equipment: "dumbbell",
+        force: "push",
+        id: "goblet-squat",
+        instructions: ["Hold a dumbbell", "Squat between the knees"],
+        level: "beginner",
+        mechanic: "compound",
+        name: "Goblet Squat",
+        primary_muscles: ["quadriceps", "glutes"],
+        secondary_muscles: null,
+        tips: ["Keep the torso tall"],
+      },
+    ];
+
+    const index = new DocumentSearchIndex(exercises, {
+      getText: searchFields<Exercise>(
+        (exercise) => exercise.name,
+        (exercise) => exercise.aliases,
+        (exercise) => exercise.category,
+        (exercise) => exercise.description,
+        (exercise) => exercise.equipment,
+        (exercise) => exercise.force,
+        (exercise) => exercise.instructions,
+        (exercise) => exercise.level,
+        (exercise) => exercise.mechanic,
+        (exercise) => exercise.primary_muscles,
+        (exercise) => exercise.secondary_muscles,
+        (exercise) => exercise.tips,
+      ),
+    });
+
+    const [result] = index.search("barbell chest triceps");
+
+    expect(result.document.id).toBe("barbell-bench-press");
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,19 @@
+import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const config = [
+  ...compat.extends("next/core-web-vitals", "prettier"),
+  {
+    ignores: [".next/**", "node_modules/**", "coverage/**", "next-env.d.ts"],
+  },
+];
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "prepare": "husky",
     "test": "jest",
     "test:coverage": "jest --coverage --collectCoverageFrom='src/**/*.{ts,tsx}'",

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -12,7 +12,7 @@ import {
   CommandSeparator,
 } from "@/components/ui/command";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "./ui/button";
 import { useRouter } from "next/navigation";
 import { useCommandMenu } from "@/provider/CommandMenuContext";
@@ -20,6 +20,7 @@ import { navigationItems } from "@/components/navigation";
 import { useBlogPosts } from "@/provider/BlogPostsContext";
 import { motion } from "framer-motion";
 import { socialItems } from "@/socialItems";
+import { DocumentSearchIndex, searchFields } from "@/lib/search";
 
 export function CommandMenuButton() {
   const { toggle } = useCommandMenu();
@@ -85,6 +86,27 @@ export function CommandMenu() {
   const { open, toggle } = useCommandMenu();
 
   const { blogPosts } = useBlogPosts();
+  const [search, setSearch] = useState("");
+
+  const blogSearchIndex = useMemo(
+    () =>
+      new DocumentSearchIndex(blogPosts, {
+        getText: searchFields(
+          (post) => post.metadata.title,
+          (post) => post.metadata.summary,
+          (post) => post.content,
+        ),
+      }),
+    [blogPosts],
+  );
+
+  const rankedBlogPosts = useMemo(() => {
+    const trimmedSearch = search.trim();
+    if (!trimmedSearch) return blogPosts;
+
+    const results = blogSearchIndex.search(trimmedSearch, blogPosts.length);
+    return results.map((result) => result.document);
+  }, [blogPosts, blogSearchIndex, search]);
 
   const handleSelect = (path: string, external: boolean | undefined) => {
     toggle();
@@ -110,7 +132,11 @@ export function CommandMenu() {
   return (
     <div className="space-y-4">
       <CommandDialog open={open} onOpenChange={toggle}>
-        <CommandInput placeholder="Type a command or search..." />
+        <CommandInput
+          placeholder="Type a command or search..."
+          value={search}
+          onValueChange={setSearch}
+        />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="External">
@@ -138,9 +164,10 @@ export function CommandMenu() {
           </CommandGroup>
           <CommandSeparator />
           <CommandGroup heading="Blog">
-            {blogPosts.map((post) => (
+            {rankedBlogPosts.map((post) => (
               <CommandItem
                 key={post.slug}
+                value={`${post.metadata.title} ${blogSearchIndex.searchableText(post)}`}
                 onSelect={() => handleSelect(`/blog/${post.slug}`, false)}
               >
                 <span>{post.metadata.title}</span>

--- a/src/lib/search/document-search.ts
+++ b/src/lib/search/document-search.ts
@@ -1,0 +1,239 @@
+export type SearchPrimitive = string | number | boolean | null | undefined;
+export type SearchFieldValue = SearchPrimitive | readonly SearchFieldValue[];
+export type SearchTextResolver<TDocument> = (
+  document: TDocument,
+) => SearchFieldValue;
+
+export type SearchResult<TDocument> = {
+  document: TDocument;
+  score: number;
+  matchedTerms: string[];
+};
+
+export type SynonymMap = Record<string, readonly string[]>;
+
+export type DocumentSearchOptions<TDocument> = {
+  getText: SearchTextResolver<TDocument>;
+  synonyms?: SynonymMap;
+  stopWords?: ReadonlySet<string>;
+  minScore?: number;
+};
+
+type IndexedDocument<TDocument> = {
+  document: TDocument;
+  vector: Map<string, number>;
+  norm: number;
+};
+
+const DEFAULT_STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "but",
+  "by",
+  "for",
+  "from",
+  "has",
+  "have",
+  "how",
+  "in",
+  "into",
+  "is",
+  "it",
+  "its",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "their",
+  "this",
+  "to",
+  "was",
+  "we",
+  "with",
+  "you",
+  "your",
+]);
+
+const DEFAULT_SYNONYMS: SynonymMap = {
+  cache: ["store", "buffer", "memoize", "cdn"],
+  client: ["browser", "frontend", "ui"],
+  clean: ["maintainable", "readable", "tidy"],
+  code: ["software", "program"],
+  delivery: ["distribution", "transport"],
+  error: ["exception", "failure", "fault"],
+  fast: ["quick", "rapid", "performant"],
+  heuristic: ["rule", "guideline", "principle"],
+  network: ["cdn", "edge", "internet"],
+  server: ["backend", "api"],
+};
+
+export class DocumentSearchIndex<TDocument> {
+  private readonly documents: IndexedDocument<TDocument>[];
+  private readonly documentFrequency = new Map<string, number>();
+  private readonly getText: SearchTextResolver<TDocument>;
+  private readonly synonyms: Map<string, string[]>;
+  private readonly stopWords: ReadonlySet<string>;
+  private readonly minScore: number;
+  private readonly documentCount: number;
+
+  constructor(
+    documents: readonly TDocument[],
+    options: DocumentSearchOptions<TDocument>,
+  ) {
+    this.getText = options.getText;
+    this.synonyms = buildBidirectionalSynonymMap({
+      ...DEFAULT_SYNONYMS,
+      ...options.synonyms,
+    });
+    this.stopWords = options.stopWords ?? DEFAULT_STOP_WORDS;
+    this.minScore = options.minScore ?? 0;
+    this.documentCount = documents.length;
+
+    const termFrequencies = documents.map((document) => ({
+      document,
+      terms: this.termFrequencies(this.documentText(document)),
+    }));
+
+    for (const { terms } of termFrequencies) {
+      for (const term of terms.keys()) {
+        this.documentFrequency.set(
+          term,
+          (this.documentFrequency.get(term) ?? 0) + 1,
+        );
+      }
+    }
+
+    this.documents = termFrequencies.map(({ document, terms }) => {
+      const vector = this.toTfIdfVector(terms);
+      return { document, vector, norm: vectorNorm(vector) };
+    });
+  }
+
+  search(query: string, limit = 5): SearchResult<TDocument>[] {
+    const queryVector = this.toTfIdfVector(this.termFrequencies(query));
+    const queryNorm = vectorNorm(queryVector);
+    if (queryNorm === 0) return [];
+
+    return this.documents
+      .map(({ document, vector, norm }) => ({
+        document,
+        score: cosineSimilarity(queryVector, queryNorm, vector, norm),
+        matchedTerms: intersectTerms(queryVector, vector),
+      }))
+      .filter((result) => result.score > this.minScore)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+  }
+
+  searchableText(document: TDocument): string {
+    return this.tokenize(this.documentText(document)).join(" ");
+  }
+
+  private documentText(document: TDocument) {
+    return flattenSearchFieldValue(this.getText(document)).join(" ");
+  }
+
+  private termFrequencies(text: string) {
+    const terms = new Map<string, number>();
+    for (const term of this.tokenize(text)) {
+      terms.set(term, (terms.get(term) ?? 0) + 1);
+    }
+    return terms;
+  }
+
+  private tokenize(text: string) {
+    const normalized = text
+      .toLowerCase()
+      .replace(/```[\s\S]*?```/g, " ")
+      .replace(/[^\p{L}\p{N}]+/gu, " ")
+      .trim();
+
+    if (!normalized) return [];
+
+    return normalized
+      .split(/\s+/)
+      .map(stem)
+      .filter((term) => term.length > 1 && !this.stopWords.has(term))
+      .flatMap((term) => [term, ...(this.synonyms.get(term) ?? [])]);
+  }
+
+  private toTfIdfVector(terms: Map<string, number>) {
+    const vector = new Map<string, number>();
+    for (const [term, count] of terms) {
+      const df = this.documentFrequency.get(term) ?? 0;
+      const idf = Math.log(this.documentCount + 1) - Math.log(df + 1) + 1;
+      vector.set(term, (1 + Math.log(count)) * idf);
+    }
+    return vector;
+  }
+}
+
+export function searchFields<TDocument>(
+  ...resolvers: SearchTextResolver<TDocument>[]
+): SearchTextResolver<TDocument> {
+  return (document) => resolvers.map((resolver) => resolver(document));
+}
+
+function flattenSearchFieldValue(value: SearchFieldValue): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => flattenSearchFieldValue(item));
+  }
+
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  return [String(value)];
+}
+
+function buildBidirectionalSynonymMap(synonyms: SynonymMap) {
+  const map = new Map<string, Set<string>>();
+  for (const [term, related] of Object.entries(synonyms)) {
+    const normalizedTerm = stem(term.toLowerCase());
+    for (const synonym of related) {
+      const normalizedSynonym = stem(synonym.toLowerCase());
+      if (!map.has(normalizedTerm)) map.set(normalizedTerm, new Set());
+      if (!map.has(normalizedSynonym)) map.set(normalizedSynonym, new Set());
+      map.get(normalizedTerm)!.add(normalizedSynonym);
+      map.get(normalizedSynonym)!.add(normalizedTerm);
+    }
+  }
+  return new Map([...map.entries()].map(([key, values]) => [key, [...values]]));
+}
+
+function stem(term: string) {
+  return term
+    .replace(/ies$/, "y")
+    .replace(/(ingly|edly|ing|ed|ly|es|s)$/, "")
+    .replace(/(.)\1$/, "$1");
+}
+
+function vectorNorm(vector: Map<string, number>) {
+  return Math.sqrt(
+    [...vector.values()].reduce((sum, value) => sum + value * value, 0),
+  );
+}
+
+function cosineSimilarity(
+  a: Map<string, number>,
+  aNorm: number,
+  b: Map<string, number>,
+  bNorm: number,
+) {
+  if (aNorm === 0 || bNorm === 0) return 0;
+  let dot = 0;
+  for (const [term, value] of a) {
+    dot += value * (b.get(term) ?? 0);
+  }
+  return dot / (aNorm * bNorm);
+}
+
+function intersectTerms(a: Map<string, number>, b: Map<string, number>) {
+  return [...a.keys()].filter((term) => b.has(term));
+}

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -1,0 +1,9 @@
+export {
+  DocumentSearchIndex,
+  searchFields,
+  type DocumentSearchOptions,
+  type SearchFieldValue,
+  type SearchTextResolver,
+  type SearchResult,
+  type SynonymMap,
+} from "./document-search";


### PR DESCRIPTION
### Motivation

- Provide a reusable, package-like document search utility that ranks documents by relevance using TF-IDF and supports synonyms and stop words.
- Improve the Command Menu experience by enabling search and ranking of blog posts within the command palette.
- Add tests to verify relevance ranking, synonym expansion, and indexing of heterogeneous document shapes.

### Description

- Add `DocumentSearchIndex` implementing tokenization, stemming, TF-IDF vectorization, cosine similarity scoring, bidirectional synonym expansion, and configurable stop words in `src/lib/search/document-search.ts`. 
- Export `DocumentSearchIndex` and `searchFields` from `src/lib/search/index.ts` and add a `searchFields` helper that composes multiple field resolvers.
- Integrate the search index into the command palette in `src/components/CommandMenu.tsx` with memoized index creation, a `search` state, `rankedBlogPosts` derived from search results, and use `searchableText` for item values.
- Add unit tests in `__tests__/document-search.test.ts` covering field selection ranking, synonym expansion, custom synonyms, and indexing of arbitrarily-shaped objects.
- Add an ESLint flat config in `eslint.config.mjs` and update the `lint` script in `package.json` to use `eslint .`.

### Testing

- Ran the test suite with `npm test` (Jest) which executed the new `__tests__/document-search.test.ts` and related tests, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a38ea68a88324a7fc58c795878288)